### PR TITLE
Ensure interface implementation and switch to blackbox testing on mem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,7 @@ language: go
 
 go:
   - 1.8.x
+  - 1.9
   - master
+
+go_import_path: github.com/zerofox-oss/go-msg

--- a/mem/example_test.go
+++ b/mem/example_test.go
@@ -1,4 +1,4 @@
-package mem
+package mem_test
 
 import (
 	"context"
@@ -6,7 +6,8 @@ import (
 	"fmt"
 	"sort"
 
-	msg "github.com/zerofox-oss/go-msg"
+	"github.com/zerofox-oss/go-msg"
+	"github.com/zerofox-oss/go-msg/mem"
 )
 
 func Example_primitives() {
@@ -14,8 +15,8 @@ func Example_primitives() {
 	c2 := make(chan *msg.Message, 10)
 	c3 := make(chan *msg.Message, 10)
 
-	t1, t2, t3 := Topic{C: c1}, Topic{C: c2}, Topic{C: c3}
-	srv1, srv2 := NewServer(c1, 1), NewServer(c2, 1)
+	t1, t2, t3 := mem.Topic{C: c1}, mem.Topic{C: c2}, mem.Topic{C: c3}
+	srv1, srv2 := mem.NewServer(c1, 1), mem.NewServer(c2, 1)
 
 	// split csv into separate messages for analysis
 	go func() {

--- a/mem/server.go
+++ b/mem/server.go
@@ -27,6 +27,9 @@ type Server struct {
 	receiverCancelFunc context.CancelFunc
 }
 
+// Ensure that Server implements msg.Server
+var _ msg.Server = &Server{}
+
 // Serve always returns a non-nil error.
 // After Shutdown, the returned error is ErrServerClosed
 func (s *Server) Serve(r msg.Receiver) error {

--- a/mem/server_test.go
+++ b/mem/server_test.go
@@ -1,4 +1,4 @@
-package mem
+package mem_test
 
 import (
 	"bytes"
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/zerofox-oss/go-msg"
+	"github.com/zerofox-oss/go-msg/mem"
 )
 
 // ConcurrentReceiver writes to an channel upon consumption of a Message.
@@ -90,7 +91,7 @@ func TestServer_Serve(t *testing.T) {
 		},
 	}
 
-	srv := NewServer(make(chan *msg.Message, len(messages)), 1)
+	srv := mem.NewServer(make(chan *msg.Message, len(messages)), 1)
 
 	for _, m := range messages {
 		srv.C <- m
@@ -127,7 +128,7 @@ func TestServer_ServeConcurrency(t *testing.T) {
 		}
 	}
 
-	srv := NewServer(make(chan *msg.Message, len(messages)), 10)
+	srv := mem.NewServer(make(chan *msg.Message, len(messages)), 10)
 
 	for _, m := range messages {
 		srv.C <- m
@@ -163,7 +164,7 @@ func TestServer_ServeCanRetryMessages(t *testing.T) {
 		},
 	}
 
-	srv := NewServer(make(chan *msg.Message, len(messages)), 1)
+	srv := mem.NewServer(make(chan *msg.Message, len(messages)), 1)
 
 	for _, m := range messages {
 		srv.C <- m
@@ -203,7 +204,7 @@ func TestServer_ShutdownContextTimeoutExceeded(t *testing.T) {
 		Body:       bytes.NewBufferString("hello world!"),
 	}
 
-	srv := NewServer(make(chan *msg.Message, 1), 1)
+	srv := mem.NewServer(make(chan *msg.Message, 1), 1)
 	defer close(srv.C)
 
 	receiver := msg.ReceiverFunc(func(ctx context.Context, m *msg.Message) error {

--- a/mem/topic.go
+++ b/mem/topic.go
@@ -12,6 +12,9 @@ type Topic struct {
 	C chan *msg.Message
 }
 
+// Ensure that Topic implements msg.Topic
+var _ msg.Topic = &Topic{}
+
 // NewWriter returns a MessageWriter.
 // The MessageWriter may be used to write messages to a channel.
 func (t *Topic) NewWriter() msg.MessageWriter {

--- a/mem/topic_test.go
+++ b/mem/topic_test.go
@@ -1,13 +1,14 @@
-package mem
+package mem_test
 
 import (
 	"testing"
 
 	"github.com/zerofox-oss/go-msg"
+	"github.com/zerofox-oss/go-msg/mem"
 )
 
 func TestMessageWriter_Attributes(t *testing.T) {
-	testTopic := Topic{}
+	testTopic := &mem.Topic{}
 
 	w := testTopic.NewWriter()
 	attrs := w.Attributes()
@@ -20,7 +21,7 @@ func TestMessageWriter_Attributes(t *testing.T) {
 
 func TestMessageWriter_WriteAndClose(t *testing.T) {
 	channel := make(chan *msg.Message)
-	testTopic := Topic{
+	testTopic := &mem.Topic{
 		C: channel,
 	}
 
@@ -48,7 +49,7 @@ func TestMessageWriter_WriteAndClose(t *testing.T) {
 // asserts MessageWriter can only be used once
 func TestMesageWriter_SingleUse(t *testing.T) {
 	channel := make(chan *msg.Message)
-	testTopic := Topic{
+	testTopic := &mem.Topic{
 		C: channel,
 	}
 

--- a/msg.go
+++ b/msg.go
@@ -125,7 +125,7 @@ type Server interface {
 	//
 	// Serve will return ErrServerClosed after Shutdown completes. Additional
 	// error types should be considered to represent error conditions unique
-	// to the implemetnation of a specific technology.
+	// to the implementation of a specific technology.
 	//
 	// Serve() should continue to listen until Shutdown is called on
 	// the Server.


### PR DESCRIPTION
The blackbox testing was just a thought, but I think we definitely should assert interface compliance at compile time in the `mem` implementation.

I also hardcoded the import path so forks can run on travis.