### PR TITLE
mem: Check if buffer is not empty before writing to channel

### DIFF
--- a/backends/mem/topic.go
+++ b/backends/mem/topic.go
@@ -56,11 +56,13 @@ func (w *MessageWriter) Close() error {
 	}
 	w.closed = true
 
-	msg := &msg.Message{
-		Attributes: w.attributes,
-		Body:       w.buf,
+	if w.buf.Len() > 0 {
+		msg := &msg.Message{
+			Attributes: w.attributes,
+			Body:       w.buf,
+		}
+		w.c <- msg
 	}
-	w.c <- msg
 
 	return nil
 }

--- a/backends/mem/topic_test.go
+++ b/backends/mem/topic_test.go
@@ -89,3 +89,23 @@ func TestMesageWriter_SingleUse(t *testing.T) {
 		t.Errorf("expected %s got %s", string(text[0]), string(body))
 	}
 }
+
+// asserts MessageWriter does not emit an empty message on Close if Write was never called.
+func TestMesageWriter_CloseEmpty(t *testing.T) {
+	channel := make(chan *msg.Message)
+	testTopic := &mem.Topic{
+		C: channel,
+	}
+
+	w := testTopic.NewWriter(context.Background())
+
+	if err := w.Close(); err != nil {
+		t.Error(err)
+	}
+
+	count := len(channel)
+
+	if count != 0 {
+		t.Errorf("got %d messages in channel, wanted 0", count)
+	}
+}


### PR DESCRIPTION
If a call to Close was made on the mem.MessageWriter without ever
calling Write, it would still write a msg.Message to the channel with an
empty Body. This caused any Receiver to get a bogus message.

Instead, this adds a check to make sure the buffer is not empty before
creating a msg.Message and writing it to the channel.